### PR TITLE
Add video call and whiteboard plugin

### DIFF
--- a/video-whiteboard/assets/js/video-whiteboard.js
+++ b/video-whiteboard/assets/js/video-whiteboard.js
@@ -1,0 +1,76 @@
+(function(){
+    const peer = new Peer();
+    const localVideo = document.getElementById('vw-local-video');
+    const remoteVideo = document.getElementById('vw-remote-video');
+    const whiteboard = document.getElementById('vw-whiteboard');
+    const ctx = whiteboard.getContext('2d');
+    let localStream;
+    let dataConn;
+    let drawing = false;
+    let lastPos = {x:0, y:0};
+
+    peer.on('open', id => {
+        const myIdElem = document.getElementById('vw-my-id');
+        if (myIdElem) {
+            myIdElem.textContent = id;
+        }
+    });
+
+    navigator.mediaDevices.getUserMedia({video: true, audio: true}).then(stream => {
+        localStream = stream;
+        localVideo.srcObject = stream;
+
+        peer.on('call', call => {
+            call.answer(stream);
+            call.on('stream', remoteStream => {
+                remoteVideo.srcObject = remoteStream;
+            });
+        });
+    });
+
+    document.getElementById('vw-connect').addEventListener('click', () => {
+        const remoteId = document.getElementById('vw-peer-id').value;
+        if (!remoteId) return;
+        dataConn = peer.connect(remoteId);
+        dataConn.on('data', drawFromData);
+        const call = peer.call(remoteId, localStream);
+        call.on('stream', remoteStream => {
+            remoteVideo.srcObject = remoteStream;
+        });
+    });
+
+    peer.on('connection', conn => {
+        dataConn = conn;
+        dataConn.on('data', drawFromData);
+    });
+
+    function drawLine(x1, y1, x2, y2){
+        ctx.beginPath();
+        ctx.moveTo(x1, y1);
+        ctx.lineTo(x2, y2);
+        ctx.stroke();
+    }
+
+    function drawFromData(data){
+        drawLine(data.x1, data.y1, data.x2, data.y2);
+    }
+
+    whiteboard.addEventListener('mousedown', e => {
+        drawing = true;
+        lastPos = {x: e.offsetX, y: e.offsetY};
+    });
+
+    whiteboard.addEventListener('mouseup', () => drawing = false);
+    whiteboard.addEventListener('mouseleave', () => drawing = false);
+
+    whiteboard.addEventListener('mousemove', e => {
+        if (!drawing) return;
+        const x = e.offsetX;
+        const y = e.offsetY;
+        drawLine(lastPos.x, lastPos.y, x, y);
+        if (dataConn && dataConn.open) {
+            dataConn.send({x1: lastPos.x, y1: lastPos.y, x2: x, y2: y});
+        }
+        lastPos = {x, y};
+    });
+})();

--- a/video-whiteboard/video-whiteboard.php
+++ b/video-whiteboard/video-whiteboard.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Plugin Name: Video Whiteboard
+ * Description: Allows two users to video call and share a whiteboard.
+ * Version: 1.0.0
+ * Author: OpenAI ChatGPT
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Enqueue required scripts
+function vw_enqueue_scripts() {
+    wp_enqueue_script(
+        'peerjs',
+        'https://unpkg.com/peerjs@1.5.2/dist/peerjs.min.js',
+        array(),
+        '1.5.2',
+        true
+    );
+    wp_enqueue_script(
+        'vw-script',
+        plugin_dir_url( __FILE__ ) . 'assets/js/video-whiteboard.js',
+        array( 'peerjs' ),
+        '1.0.0',
+        true
+    );
+}
+add_action( 'wp_enqueue_scripts', 'vw_enqueue_scripts' );
+
+// Shortcode to render video call and whiteboard interface
+function vw_shortcode() {
+    ob_start();
+    ?>
+    <div id="vw-container">
+        <video id="vw-local-video" autoplay playsinline muted></video>
+        <video id="vw-remote-video" autoplay playsinline></video>
+        <canvas id="vw-whiteboard" width="600" height="400" style="border:1px solid #000"></canvas>
+        <div>
+            <input type="text" id="vw-peer-id" placeholder="Peer ID to connect">
+            <button id="vw-connect">Connect</button>
+            <span>Your ID: <span id="vw-my-id"></span></span>
+        </div>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode( 'video_whiteboard', 'vw_shortcode' );


### PR DESCRIPTION
## Summary
- add Video Whiteboard plugin with shortcode for two-user WebRTC video calls and drawing board
- include front-end script using PeerJS and canvas drawing synchronization

## Testing
- `php -l video-whiteboard/video-whiteboard.php`
- `node --check video-whiteboard/assets/js/video-whiteboard.js`

------
https://chatgpt.com/codex/tasks/task_e_68b363ce77bc8333b7ee84fbf148d29e